### PR TITLE
Add navigation component for main pages

### DIFF
--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -5,18 +5,19 @@ export const routes: Routes = [
     path: 'home',
     loadComponent: () => import('./pages/home/home.page').then((m) => m.HomePage),
   },
-  { path: 'quotes', loadComponent: () => import('./pages/quotes/quotes.page').then(m => m.QuotesPage) },
+  {
+    path: 'quotes',
+    loadComponent: () =>
+      import('./pages/quotes/quotes.page').then((m) => m.QuotesPage),
+  },
+  {
+    path: 'settings',
+    loadComponent: () =>
+      import('./pages/settings/settings.page').then((m) => m.SettingsPage),
+  },
   {
     path: '',
     redirectTo: 'home',
     pathMatch: 'full',
-  },
-  {
-    path: 'quotes',
-    loadComponent: () => import('./pages/quotes/quotes.page').then( m => m.QuotesPage)
-  },
-  {
-    path: 'settings',
-    loadComponent: () => import('./pages/settings/settings.page').then( m => m.SettingsPage)
   },
 ];

--- a/src/app/components/nav/nav.component.html
+++ b/src/app/components/nav/nav.component.html
@@ -1,0 +1,16 @@
+<ion-toolbar>
+  <ion-buttons>
+    <ion-button routerLink="/home">
+      <ion-icon name="home-outline" slot="start"></ion-icon>
+      Home
+    </ion-button>
+    <ion-button routerLink="/quotes">
+      <ion-icon name="chatbubbles-outline" slot="start"></ion-icon>
+      Quotes
+    </ion-button>
+    <ion-button routerLink="/settings">
+      <ion-icon name="settings-outline" slot="start"></ion-icon>
+      Settings
+    </ion-button>
+  </ion-buttons>
+</ion-toolbar>

--- a/src/app/components/nav/nav.component.scss
+++ b/src/app/components/nav/nav.component.scss
@@ -1,0 +1,4 @@
+/* Styles for navigation toolbar */
+ion-toolbar {
+  --background: var(--ion-color-light);
+}

--- a/src/app/components/nav/nav.component.spec.ts
+++ b/src/app/components/nav/nav.component.spec.ts
@@ -1,0 +1,22 @@
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+
+import { NavComponent } from './nav.component';
+
+describe('NavComponent', () => {
+  let component: NavComponent;
+  let fixture: ComponentFixture<NavComponent>;
+
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [NavComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(NavComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  }));
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/components/nav/nav.component.ts
+++ b/src/app/components/nav/nav.component.ts
@@ -1,0 +1,12 @@
+import { Component } from '@angular/core';
+import { IonToolbar, IonButtons, IonButton, IonIcon } from '@ionic/angular/standalone';
+import { RouterLink } from '@angular/router';
+
+@Component({
+  selector: 'app-nav',
+  standalone: true,
+  templateUrl: './nav.component.html',
+  styleUrls: ['./nav.component.scss'],
+  imports: [IonToolbar, IonButtons, IonButton, IonIcon, RouterLink],
+})
+export class NavComponent {}

--- a/src/app/pages/home/home.page.html
+++ b/src/app/pages/home/home.page.html
@@ -16,3 +16,6 @@
     <app-quote></app-quote>
   </div>
 </ion-content>
+<ion-footer>
+  <app-nav></app-nav>
+</ion-footer>

--- a/src/app/pages/home/home.page.ts
+++ b/src/app/pages/home/home.page.ts
@@ -1,13 +1,28 @@
 import { Component } from '@angular/core';
-import { IonHeader, IonToolbar, IonTitle, IonContent } from '@ionic/angular/standalone';
+import {
+  IonHeader,
+  IonToolbar,
+  IonTitle,
+  IonContent,
+  IonFooter,
+} from '@ionic/angular/standalone';
 import { QuoteComponent } from 'src/app/components/quote/quote.component';
+import { NavComponent } from 'src/app/components/nav/nav.component';
 
 @Component({
   selector: 'app-home',
   standalone: true,
   templateUrl: 'home.page.html',
   styleUrls: ['home.page.scss'],
-  imports: [IonHeader, IonToolbar, IonTitle, IonContent, QuoteComponent],
+  imports: [
+    IonHeader,
+    IonToolbar,
+    IonTitle,
+    IonContent,
+    IonFooter,
+    QuoteComponent,
+    NavComponent,
+  ],
 })
 export class HomePage {
   constructor() {}

--- a/src/app/pages/quotes/quotes.page.html
+++ b/src/app/pages/quotes/quotes.page.html
@@ -12,5 +12,8 @@
   </ion-header>
   <app-quote-list></app-quote-list>
 </ion-content>
+<ion-footer>
+  <app-nav></app-nav>
+</ion-footer>
 
 

--- a/src/app/pages/quotes/quotes.page.ts
+++ b/src/app/pages/quotes/quotes.page.ts
@@ -1,15 +1,32 @@
 import { Component, OnInit } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
-import { IonContent, IonHeader, IonTitle, IonToolbar } from '@ionic/angular/standalone';
+import {
+  IonContent,
+  IonHeader,
+  IonTitle,
+  IonToolbar,
+  IonFooter,
+} from '@ionic/angular/standalone';
 import { ListComponent } from 'src/app/components/list/list.component';
+import { NavComponent } from 'src/app/components/nav/nav.component';
 
 @Component({
   selector: 'app-quotes',
   templateUrl: './quotes.page.html',
   styleUrls: ['./quotes.page.scss'],
   standalone: true,
-  imports: [IonContent, IonHeader, IonTitle, IonToolbar, CommonModule, FormsModule, ListComponent]
+  imports: [
+    IonContent,
+    IonHeader,
+    IonTitle,
+    IonToolbar,
+    IonFooter,
+    CommonModule,
+    FormsModule,
+    ListComponent,
+    NavComponent,
+  ]
 })
 export class QuotesPage implements OnInit {
 

--- a/src/app/pages/settings/settings.page.html
+++ b/src/app/pages/settings/settings.page.html
@@ -14,5 +14,8 @@
   <div>
     <ion-toggle [enableOnOffLabels]="true" labelPlacement="stacked" aria-label="Tertiary toggle" color="tertiary" [checked]="true" alignment="center">¿Desea poder borrar citas en el inicio (frase aleatoria)?</ion-toggle>
   </div>
-  
+
 </ion-content>
+<ion-footer>
+  <app-nav></app-nav>
+</ion-footer>

--- a/src/app/pages/settings/settings.page.ts
+++ b/src/app/pages/settings/settings.page.ts
@@ -1,14 +1,32 @@
 import { Component, OnInit } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
-import { IonContent, IonHeader, IonTitle, IonToolbar, IonToggle } from '@ionic/angular/standalone';
+import {
+  IonContent,
+  IonHeader,
+  IonTitle,
+  IonToolbar,
+  IonToggle,
+  IonFooter,
+} from '@ionic/angular/standalone';
+import { NavComponent } from 'src/app/components/nav/nav.component';
 
 @Component({
   selector: 'app-settings',
   templateUrl: './settings.page.html',
   styleUrls: ['./settings.page.scss'],
   standalone: true,
-  imports: [IonToggle, IonContent, IonHeader, IonTitle, IonToolbar, CommonModule, FormsModule]
+  imports: [
+    IonToggle,
+    IonContent,
+    IonHeader,
+    IonTitle,
+    IonToolbar,
+    IonFooter,
+    CommonModule,
+    FormsModule,
+    NavComponent,
+  ]
 })
 export class SettingsPage implements OnInit {
 


### PR DESCRIPTION
## Summary
- create standalone navigation toolbar linking to Home, Quotes, and Settings
- integrate navigation footer into Home, Quotes, and Settings pages
- tidy routes to include Home, Quotes, and Settings paths

## Testing
- `npm test -- --watch=false --browsers=ChromeHeadless --progress=false` *(fails: No binary for ChromeHeadless)*
- `npm run lint` *(fails: lint errors in existing files)*

------
https://chatgpt.com/codex/tasks/task_e_68b5a23890f88322908b9330edcb9a4d