### PR TITLE
Add quote creation form and configurable deletion option

### DIFF
--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -1,0 +1,17 @@
+module.exports = {
+  preset: 'jest-preset-angular',
+  setupFilesAfterEnv: ['<rootDir>/setup-jest.ts'],
+  testEnvironment: 'jsdom',
+  transform: {
+    '^.+\\.(ts|mjs|html)$': [
+      'ts-jest',
+      {
+        tsconfig: 'tsconfig.spec.json',
+        stringifyContentPathRegex: '\\.(html)$',
+      },
+    ],
+  },
+  moduleFileExtensions: ['ts', 'html', 'js', 'json'],
+  testMatch: ['**/+(*.)+(spec).+(ts)'],
+  resolver: 'jest-preset-angular/build/resolvers/ng-jest-resolver.js'
+};

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "start": "ng serve",
     "build": "ng build",
     "watch": "ng build --watch --configuration development",
-    "test": "ng test",
+    "test": "jest",
     "lint": "ng lint",
     "ionic:build": "npm run build",
     "ionic:serve": "npm run start -- --open"

--- a/setup-jest.ts
+++ b/setup-jest.ts
@@ -1,0 +1,1 @@
+import 'jest-preset-angular/setup-jest';

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -5,18 +5,19 @@ export const routes: Routes = [
     path: 'home',
     loadComponent: () => import('./pages/home/home.page').then((m) => m.HomePage),
   },
-  { path: 'quotes', loadComponent: () => import('./pages/quotes/quotes.page').then(m => m.QuotesPage) },
+  {
+    path: 'quotes',
+    loadComponent: () =>
+      import('./pages/quotes/quotes.page').then((m) => m.QuotesPage),
+  },
+  {
+    path: 'settings',
+    loadComponent: () =>
+      import('./pages/settings/settings.page').then((m) => m.SettingsPage),
+  },
   {
     path: '',
     redirectTo: 'home',
     pathMatch: 'full',
-  },
-  {
-    path: 'quotes',
-    loadComponent: () => import('./pages/quotes/quotes.page').then( m => m.QuotesPage)
-  },
-  {
-    path: 'settings',
-    loadComponent: () => import('./pages/settings/settings.page').then( m => m.SettingsPage)
   },
 ];

--- a/src/app/components/list/list.component.spec.ts
+++ b/src/app/components/list/list.component.spec.ts
@@ -1,16 +1,19 @@
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 
 import { ListComponent } from './list.component';
+import { QuoteService } from 'src/app/core/quote.service';
 
 describe('ListComponent', () => {
   let component: ListComponent;
   let fixture: ComponentFixture<ListComponent>;
+  let service: QuoteService;
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       imports: [ListComponent],
     }).compileComponents();
 
+    service = TestBed.inject(QuoteService);
     fixture = TestBed.createComponent(ListComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();
@@ -18,5 +21,11 @@ describe('ListComponent', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('should remove item via service', () => {
+    const initialLength = service.getAllQuotes().length;
+    component.eliminar(0);
+    expect(service.getAllQuotes().length).toBe(initialLength - 1);
   });
 });

--- a/src/app/components/list/list.component.ts
+++ b/src/app/components/list/list.component.ts
@@ -1,28 +1,22 @@
 import { CommonModule } from '@angular/common';
-import { Component, OnInit } from '@angular/core';
-import { IonLabel, IonItem, IonContent, IonList, IonCard, IonCardTitle, IonCardHeader, IonCardSubtitle, IonCardContent, IonButton } from "@ionic/angular/standalone";
-import { QuoteService } from 'src/app/core/quote.service';
+import { Component, inject } from '@angular/core';
+import { IonContent, IonList, IonCard, IonCardTitle, IonCardHeader, IonCardSubtitle, IonCardContent, IonButton } from "@ionic/angular/standalone";
+import { QuoteService, Quote } from 'src/app/core/quote.service';
 
 @Component({
   selector: 'app-quote-list',
   templateUrl: './list.component.html',
   styleUrls: ['./list.component.scss'],
   standalone: true,
-  imports: [IonButton, IonCardContent, IonCardSubtitle, IonCardHeader, IonCardTitle, IonCard, IonList, IonContent, CommonModule],
-  providers: [QuoteService]
+  imports: [IonButton, IonCardContent, IonCardSubtitle, IonCardHeader, IonCardTitle, IonCard, IonList, IonContent, CommonModule]
 })
-export class ListComponent  implements OnInit {
-
-  
-
-  constructor(private quoteService: QuoteService) {
-    this.quoteService = quoteService;
-   }
-
-  items = this.quoteService.getAllQuotes();
-  ngOnInit() {}
+export class ListComponent {
+  private quoteService = inject(QuoteService);
+  items: ReadonlyArray<Quote> = this.quoteService.getAllQuotes();
 
   eliminar(index: number) {
-    this.items.splice(index, 1);
+    const quote = this.items[index];
+    this.quoteService.removeQuote(quote);
+    this.items = this.quoteService.getAllQuotes();
   }
 }

--- a/src/app/components/nav/nav.component.html
+++ b/src/app/components/nav/nav.component.html
@@ -1,0 +1,17 @@
+<ion-toolbar>
+  <ion-buttons slot="start">
+    <ion-button routerLink="/home">
+      <ion-icon name="home-outline" slot="start"></ion-icon>
+      Home
+    </ion-button>
+    <ion-button routerLink="/quotes">
+      <ion-icon name="chatbubbles-outline" slot="start"></ion-icon>
+      Quotes
+    </ion-button>
+  </ion-buttons>
+  <ion-buttons slot="end">
+    <ion-button routerLink="/settings">
+      <ion-icon name="settings-outline" slot="icon-only"></ion-icon>
+    </ion-button>
+  </ion-buttons>
+</ion-toolbar>

--- a/src/app/components/nav/nav.component.scss
+++ b/src/app/components/nav/nav.component.scss
@@ -1,0 +1,4 @@
+/* Styles for navigation toolbar */
+ion-toolbar {
+  --background: var(--ion-color-light);
+}

--- a/src/app/components/nav/nav.component.spec.ts
+++ b/src/app/components/nav/nav.component.spec.ts
@@ -1,0 +1,27 @@
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+
+import { NavComponent } from './nav.component';
+
+describe('NavComponent', () => {
+  let component: NavComponent;
+  let fixture: ComponentFixture<NavComponent>;
+
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [NavComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(NavComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  }));
+
+    it('should create', () => {
+      expect(component).toBeTruthy();
+    });
+
+    it('should have settings icon button on the right', () => {
+      const button = fixture.nativeElement.querySelector('ion-buttons[slot="end"] ion-button');
+      expect(button?.getAttribute('routerLink')).toBe('/settings');
+    });
+  });

--- a/src/app/components/nav/nav.component.ts
+++ b/src/app/components/nav/nav.component.ts
@@ -1,0 +1,16 @@
+import { Component } from '@angular/core';
+import { IonToolbar, IonButtons, IonButton, IonIcon } from '@ionic/angular/standalone';
+import { RouterLink } from '@angular/router';
+import { addIcons } from 'ionicons';
+import { homeOutline, chatbubblesOutline, settingsOutline } from 'ionicons/icons';
+
+addIcons({ homeOutline, chatbubblesOutline, settingsOutline });
+
+@Component({
+  selector: 'app-nav',
+  standalone: true,
+  templateUrl: './nav.component.html',
+  styleUrls: ['./nav.component.scss'],
+  imports: [IonToolbar, IonButtons, IonButton, IonIcon, RouterLink],
+})
+export class NavComponent {}

--- a/src/app/components/quote/quote.component.html
+++ b/src/app/components/quote/quote.component.html
@@ -6,6 +6,10 @@
 
   <ion-card-content>
     <p>Inspiración al azar ✨</p>
+    <ion-button *ngIf="allowDelete" color="danger" (click)="onDelete()">
+      <ion-icon name="trash-outline" slot="start"></ion-icon>
+      Borrar
+    </ion-button>
   </ion-card-content>
 </ion-card>
 

--- a/src/app/components/quote/quote.component.spec.ts
+++ b/src/app/components/quote/quote.component.spec.ts
@@ -19,4 +19,18 @@ describe('QuoteComponent', () => {
   it('should create', () => {
     expect(component).toBeTruthy();
   });
+
+  it('should hide delete button by default', () => {
+    const button = fixture.nativeElement.querySelector('ion-button');
+    expect(button).toBeNull();
+  });
+
+  it('should emit deleted when delete button clicked', () => {
+    component.allowDelete = true;
+    jest.spyOn(component.deleted, 'emit');
+    fixture.detectChanges();
+    const button: HTMLElement = fixture.nativeElement.querySelector('ion-button');
+    button.click();
+    expect(component.deleted.emit).toHaveBeenCalled();
+  });
 });

--- a/src/app/components/quote/quote.component.ts
+++ b/src/app/components/quote/quote.component.ts
@@ -1,28 +1,57 @@
-import { Component, OnInit } from '@angular/core';
-import { IonCardContent, IonCardSubtitle, IonCardTitle, IonCard, IonCardHeader } from "@ionic/angular/standalone";
-import { QuoteService } from '../../core/quote.service';
+import { Component, EventEmitter, Input, Output, inject } from '@angular/core';
+import {
+  IonCardContent,
+  IonCardSubtitle,
+  IonCardTitle,
+  IonCard,
+  IonCardHeader,
+  IonButton,
+  IonIcon,
+} from "@ionic/angular/standalone";
+import { QuoteService, Quote } from '../../core/quote.service';
 import { CommonModule } from '@angular/common';
+import { addIcons } from 'ionicons';
+import { trashOutline } from 'ionicons/icons';
+
+addIcons({ trashOutline });
 
 @Component({
   selector: 'app-quote',
   templateUrl: './quote.component.html',
   styleUrls: ['./quote.component.scss'],
   standalone: true,
-  imports: [IonCardHeader, IonCardTitle, IonCardSubtitle, IonCardContent, IonCard, CommonModule],
+  imports: [
+    IonCardHeader,
+    IonCardTitle,
+    IonCardSubtitle,
+    IonCardContent,
+    IonCard,
+    IonButton,
+    IonIcon,
+    CommonModule,
+  ],
 })
 
-export class QuoteComponent implements OnInit {
-  constructor(private quoteService: QuoteService) {
-    this.quoteService = new QuoteService();
-   }
-   
+export class QuoteComponent {
+  @Input() allowDelete = false;
+  @Output() deleted = new EventEmitter<void>();
 
-  ngOnInit() { this.getQuote(); }
+  private quoteService = inject(QuoteService);
+  private currentQuote: Quote | null = this.quoteService.getRandomQuote();
 
-  quote: { text: string; author: string } | null = null;
-
-  getQuote() {
-    this.quote = this.quoteService.getRandomQuote();
+  get quote(): Quote | null {
+    return this.currentQuote;
   }
 
+  getQuote() {
+    this.currentQuote = this.quoteService.getRandomQuote();
+  }
+
+  onDelete() {
+    if (this.currentQuote) {
+      this.quoteService.removeQuote(this.currentQuote);
+      this.deleted.emit();
+      this.currentQuote = this.quoteService.getRandomQuote();
+    }
+  }
 }

--- a/src/app/core/quote.service.spec.ts
+++ b/src/app/core/quote.service.spec.ts
@@ -1,0 +1,23 @@
+import { QuoteService } from './quote.service';
+
+describe('QuoteService', () => {
+  let service: QuoteService;
+
+  beforeEach(() => {
+    service = new QuoteService();
+  });
+
+  it('should return all quotes without exposing internal array', () => {
+    const quotes = service.getAllQuotes();
+    expect(quotes.length).toBeGreaterThan(0);
+    expect(quotes).not.toBe((service as any).quotes);
+  });
+
+  it('should add and remove quotes', () => {
+    const quote = { text: 'Test', author: 'Tester' };
+    service.addQuote(quote);
+    expect(service.getAllQuotes().some(q => q.text === 'Test')).toBe(true);
+    service.removeQuote(quote);
+    expect(service.getAllQuotes().some(q => q.text === 'Test')).toBe(false);
+  });
+});

--- a/src/app/core/quote.service.ts
+++ b/src/app/core/quote.service.ts
@@ -1,29 +1,37 @@
 import { Injectable } from "@angular/core";
 
+export interface Quote {
+  text: string;
+  author: string;
+}
+
 @Injectable({ providedIn: 'root' })
 export class QuoteService {
-    
-  constructor() { }
 
-    private quotes = [
-    { text: "The best way to get started is to quit talking and begin doing.",
-        author: "Walt Disney" },
-    { text: "The pessimist sees difficulty in every opportunity. The optimist sees opportunity in every difficulty.",
-        author: "Winston Churchill" },
-    { text: "Don't let yesterday take up too much of today.",
-        author: "Will Rogers" },
-    { text: "You learn more from failure than from success. Don't let it stop you . Failure builds character.",
-        author: "Unknown" },
-    { text: "It's not whether you get knocked down, it's whether you get up.",
-        author: "Vince Lombardi" }, 
-    ];
+  private quotes: Quote[] = [
+    { text: "The best way to get started is to quit talking and begin doing.", author: "Walt Disney" },
+    { text: "The pessimist sees difficulty in every opportunity. The optimist sees opportunity in every difficulty.", author: "Winston Churchill" },
+    { text: "Don't let yesterday take up too much of today.", author: "Will Rogers" },
+    { text: "You learn more from failure than from success. Don't let it stop you . Failure builds character.", author: "Unknown" },
+    { text: "It's not whether you get knocked down, it's whether you get up.", author: "Vince Lombardi" },
+  ];
 
-    getRandomQuote() {
-        const randomIndex = Math.floor(Math.random() * this.quotes.length);
-        return this.quotes[randomIndex];
-    }
+  getRandomQuote(): Quote {
+    const randomIndex = Math.floor(Math.random() * this.quotes.length);
+    return { ...this.quotes[randomIndex] };
+  }
 
-    getAllQuotes() {
-        return this.quotes;
-    }
+  getAllQuotes(): ReadonlyArray<Quote> {
+    return this.quotes.map(q => ({ ...q }));
+  }
+
+  addQuote(quote: Quote): void {
+    this.quotes.push({ ...quote });
+  }
+
+  removeQuote(quote: Quote): void {
+    this.quotes = this.quotes.filter(
+      q => q.text !== quote.text || q.author !== quote.author
+    );
+  }
 }

--- a/src/app/core/settings.service.spec.ts
+++ b/src/app/core/settings.service.spec.ts
@@ -1,0 +1,18 @@
+import { SettingsService } from './settings.service';
+
+describe('SettingsService', () => {
+  let service: SettingsService;
+
+  beforeEach(() => {
+    service = new SettingsService();
+  });
+
+  it('should default allowDelete to false', () => {
+    expect(service.getAllowDelete()).toBe(false);
+  });
+
+  it('should set and get allowDelete', () => {
+    service.setAllowDelete(true);
+    expect(service.getAllowDelete()).toBe(true);
+  });
+});

--- a/src/app/core/settings.service.ts
+++ b/src/app/core/settings.service.ts
@@ -1,0 +1,14 @@
+import { Injectable } from '@angular/core';
+
+@Injectable({ providedIn: 'root' })
+export class SettingsService {
+  private allowDelete = false;
+
+  setAllowDelete(value: boolean): void {
+    this.allowDelete = value;
+  }
+
+  getAllowDelete(): boolean {
+    return this.allowDelete;
+  }
+}

--- a/src/app/pages/home/home.page.html
+++ b/src/app/pages/home/home.page.html
@@ -13,6 +13,12 @@
     </ion-toolbar>
   </ion-header>
   <div id="container">
-    <app-quote></app-quote>
+    <app-quote
+      [allowDelete]="allowDelete"
+      (deleted)="quoteDeleted()"
+    ></app-quote>
   </div>
 </ion-content>
+<ion-footer>
+  <app-nav></app-nav>
+</ion-footer>

--- a/src/app/pages/home/home.page.spec.ts
+++ b/src/app/pages/home/home.page.spec.ts
@@ -1,18 +1,24 @@
-import { ComponentFixture, TestBed } from '@angular/core/testing';
-
+import { TestBed } from '@angular/core/testing';
 import { HomePage } from './home.page';
+import { SettingsService } from 'src/app/core/settings.service';
 
 describe('HomePage', () => {
   let component: HomePage;
-  let fixture: ComponentFixture<HomePage>;
+  let settings: SettingsService;
 
-  beforeEach(async () => {
-    fixture = TestBed.createComponent(HomePage);
-    component = fixture.componentInstance;
-    fixture.detectChanges();
+  beforeEach(() => {
+    TestBed.configureTestingModule({ imports: [HomePage] });
+    settings = TestBed.inject(SettingsService);
+    component = TestBed.createComponent(HomePage).componentInstance;
   });
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('should read allowDelete from service', () => {
+    settings.setAllowDelete(true);
+    component.ionViewWillEnter();
+    expect(component.allowDelete).toBe(true);
   });
 });

--- a/src/app/pages/home/home.page.ts
+++ b/src/app/pages/home/home.page.ts
@@ -1,14 +1,39 @@
-import { Component } from '@angular/core';
-import { IonHeader, IonToolbar, IonTitle, IonContent } from '@ionic/angular/standalone';
+import { Component, inject } from '@angular/core';
+import {
+  IonHeader,
+  IonToolbar,
+  IonTitle,
+  IonContent,
+  IonFooter,
+} from '@ionic/angular/standalone';
 import { QuoteComponent } from 'src/app/components/quote/quote.component';
+import { NavComponent } from 'src/app/components/nav/nav.component';
+import { SettingsService } from 'src/app/core/settings.service';
 
 @Component({
   selector: 'app-home',
   standalone: true,
   templateUrl: 'home.page.html',
   styleUrls: ['home.page.scss'],
-  imports: [IonHeader, IonToolbar, IonTitle, IonContent, QuoteComponent],
+  imports: [
+    IonHeader,
+    IonToolbar,
+    IonTitle,
+    IonContent,
+    IonFooter,
+    QuoteComponent,
+    NavComponent,
+  ],
 })
 export class HomePage {
-  constructor() {}
+  private settings = inject(SettingsService);
+  allowDelete = this.settings.getAllowDelete();
+
+  ionViewWillEnter() {
+    this.allowDelete = this.settings.getAllowDelete();
+  }
+
+  quoteDeleted() {
+    // placeholder for potential future actions when a quote is deleted
+  }
 }

--- a/src/app/pages/quotes/quotes.page.html
+++ b/src/app/pages/quotes/quotes.page.html
@@ -10,7 +10,19 @@
       <ion-title size="large">quotes</ion-title>
     </ion-toolbar>
   </ion-header>
+  <ion-list>
+    <ion-item>
+      <ion-input [(ngModel)]="newQuoteText" placeholder="Quote"></ion-input>
+    </ion-item>
+    <ion-item>
+      <ion-input [(ngModel)]="newQuoteAuthor" placeholder="Author"></ion-input>
+    </ion-item>
+    <ion-button expand="block" (click)="addQuote()">Add Quote</ion-button>
+  </ion-list>
   <app-quote-list></app-quote-list>
 </ion-content>
+<ion-footer>
+  <app-nav></app-nav>
+</ion-footer>
 
 

--- a/src/app/pages/quotes/quotes.page.spec.ts
+++ b/src/app/pages/quotes/quotes.page.spec.ts
@@ -1,17 +1,28 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { QuotesPage } from './quotes.page';
+import { QuoteService } from 'src/app/core/quote.service';
 
 describe('QuotesPage', () => {
   let component: QuotesPage;
   let fixture: ComponentFixture<QuotesPage>;
+  let service: QuoteService;
 
   beforeEach(() => {
     fixture = TestBed.createComponent(QuotesPage);
     component = fixture.componentInstance;
+    service = TestBed.inject(QuoteService);
     fixture.detectChanges();
   });
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('should add a quote', () => {
+    const initialLength = service.getAllQuotes().length;
+    component.newQuoteText = 'test quote';
+    component.newQuoteAuthor = 'tester';
+    component.addQuote();
+    expect(service.getAllQuotes().length).toBe(initialLength + 1);
   });
 });

--- a/src/app/pages/quotes/quotes.page.ts
+++ b/src/app/pages/quotes/quotes.page.ts
@@ -1,21 +1,53 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, inject } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
-import { IonContent, IonHeader, IonTitle, IonToolbar } from '@ionic/angular/standalone';
+import {
+  IonContent,
+  IonHeader,
+  IonTitle,
+  IonToolbar,
+  IonFooter,
+  IonItem,
+  IonInput,
+  IonButton,
+  IonList,
+} from '@ionic/angular/standalone';
 import { ListComponent } from 'src/app/components/list/list.component';
+import { NavComponent } from 'src/app/components/nav/nav.component';
+import { QuoteService, Quote } from 'src/app/core/quote.service';
 
 @Component({
   selector: 'app-quotes',
   templateUrl: './quotes.page.html',
   styleUrls: ['./quotes.page.scss'],
   standalone: true,
-  imports: [IonContent, IonHeader, IonTitle, IonToolbar, CommonModule, FormsModule, ListComponent]
+  imports: [
+    IonContent,
+    IonHeader,
+    IonTitle,
+    IonToolbar,
+    IonFooter,
+    IonItem,
+    IonInput,
+    IonButton,
+    IonList,
+    CommonModule,
+    FormsModule,
+    ListComponent,
+    NavComponent,
+  ]
 })
-export class QuotesPage implements OnInit {
+export class QuotesPage {
+  newQuoteText = '';
+  newQuoteAuthor = '';
+  private quoteService = inject(QuoteService);
 
-  constructor() { }
-
-  ngOnInit() {
+  addQuote() {
+    if (this.newQuoteText.trim() && this.newQuoteAuthor.trim()) {
+      const quote: Quote = { text: this.newQuoteText, author: this.newQuoteAuthor };
+      this.quoteService.addQuote(quote);
+      this.newQuoteText = '';
+      this.newQuoteAuthor = '';
+    }
   }
-
 }

--- a/src/app/pages/settings/settings.page.html
+++ b/src/app/pages/settings/settings.page.html
@@ -12,7 +12,19 @@
   </ion-header>
   <br>
   <div>
-    <ion-toggle [enableOnOffLabels]="true" labelPlacement="stacked" aria-label="Tertiary toggle" color="tertiary" [checked]="true" alignment="center">¿Desea poder borrar citas en el inicio (frase aleatoria)?</ion-toggle>
+    <ion-toggle
+      [enableOnOffLabels]="true"
+      labelPlacement="stacked"
+      aria-label="Tertiary toggle"
+      color="tertiary"
+      [checked]="allowDelete"
+      (ionChange)="onToggle($event)"
+      alignment="center"
+      >¿Desea poder borrar citas en el inicio (frase aleatoria)?</ion-toggle
+    >
   </div>
-  
+
 </ion-content>
+<ion-footer>
+  <app-nav></app-nav>
+</ion-footer>

--- a/src/app/pages/settings/settings.page.spec.ts
+++ b/src/app/pages/settings/settings.page.spec.ts
@@ -1,17 +1,24 @@
-import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { TestBed } from '@angular/core/testing';
 import { SettingsPage } from './settings.page';
+import { SettingsService } from 'src/app/core/settings.service';
 
 describe('SettingsPage', () => {
   let component: SettingsPage;
-  let fixture: ComponentFixture<SettingsPage>;
+  let settings: SettingsService;
 
   beforeEach(() => {
-    fixture = TestBed.createComponent(SettingsPage);
-    component = fixture.componentInstance;
-    fixture.detectChanges();
+    TestBed.configureTestingModule({ imports: [SettingsPage] });
+    settings = TestBed.inject(SettingsService);
+    component = TestBed.createComponent(SettingsPage).componentInstance;
   });
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('should toggle allowDelete', () => {
+    const event = { detail: { checked: true } } as CustomEvent;
+    component.onToggle(event);
+    expect(settings.getAllowDelete()).toBe(true);
   });
 });

--- a/src/app/pages/settings/settings.page.ts
+++ b/src/app/pages/settings/settings.page.ts
@@ -1,20 +1,41 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, inject } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
-import { IonContent, IonHeader, IonTitle, IonToolbar, IonToggle } from '@ionic/angular/standalone';
+import {
+  IonContent,
+  IonHeader,
+  IonTitle,
+  IonToolbar,
+  IonToggle,
+  IonFooter,
+} from '@ionic/angular/standalone';
+import { NavComponent } from 'src/app/components/nav/nav.component';
+import { SettingsService } from 'src/app/core/settings.service';
 
 @Component({
   selector: 'app-settings',
   templateUrl: './settings.page.html',
   styleUrls: ['./settings.page.scss'],
   standalone: true,
-  imports: [IonToggle, IonContent, IonHeader, IonTitle, IonToolbar, CommonModule, FormsModule]
+  imports: [
+    IonToggle,
+    IonContent,
+    IonHeader,
+    IonTitle,
+    IonToolbar,
+    IonFooter,
+    CommonModule,
+    FormsModule,
+    NavComponent,
+  ]
 })
-export class SettingsPage implements OnInit {
+export class SettingsPage {
+  private settings = inject(SettingsService);
+  allowDelete = this.settings.getAllowDelete();
 
-  constructor() { }
-
-  ngOnInit() {
+  onToggle(event: Event) {
+    const toggle = event as CustomEvent;
+    this.allowDelete = toggle.detail.checked;
+    this.settings.setAllowDelete(this.allowDelete);
   }
-
 }

--- a/tsconfig.spec.json
+++ b/tsconfig.spec.json
@@ -4,7 +4,7 @@
   "compilerOptions": {
     "outDir": "./out-tsc/spec",
     "types": [
-      "jasmine"
+      "jest"
     ]
   },
   "files": [


### PR DESCRIPTION
## Summary
- add addQuote method to QuoteService
- allow adding quotes through a new form on the Quotes page
- switch components to `inject` pattern and extend tests for quote creation
- add navigation component and place settings icon on the right side
- register Ionicons so the settings icon displays and wire a toggle to enable deleting random quotes
- show a delete button on the Home quote when the option is active and remove the quote from the service
- encapsulate quote and settings state with getter/setter APIs and update components accordingly
- introduce Jest config and specs for services and components

## Testing
- `npm run lint`
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b5a23890f88322908b9330edcb9a4d